### PR TITLE
API break: hide `WitnessProgram` internals

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-bech32"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Clark Moody"]
 repository = "https://github.com/clarkmoody/rust-bech32-bitcoin"
 description = "Encodes and decodes Bitcoin Segregated Witness addresses in Bech32"


### PR DESCRIPTION
This lets us serialize to strings without any error paths, to be consistent with upstream `Bech32` and downstream `Address`.