### PR TITLE
Use new rust-bech32 api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ categories = ["encoding"]
 license = "MIT"
 
 [dependencies]
-bech32 = "0.3.0"
+bech32 = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-bech32"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Clark Moody"]
 repository = "https://github.com/rust-bitcoin/rust-bech32-bitcoin"
 description = "Encodes and decodes Bitcoin Segregated Witness addresses in Bech32"

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Encodes and decodes Bitcoin Segregated Witness addresses in the Bech32 format de
 ## Example
 
 ```rust
-use bitcoin_bech32::WitnessProgram;
+use bitcoin_bech32::{WitnessProgram, u5};
 use bitcoin_bech32::constants::Network;
 
 let witness_program = WitnessProgram {
-     version: 0,
+     version: u5::try_from_u8(0).unwrap(),
      program: vec![
                  0x00, 0x00, 0x00, 0xc4, 0xa5, 0xca, 0xd4, 0x62, 
                  0x21, 0xb2, 0xa1, 0x87, 0x90, 0x5e, 0x52, 0x66, 


### PR DESCRIPTION
Usage example for rust-bitcoin/rust-bech32#17.

- [x] change bech32 dependency back to crates.io once rust-bitcoin/rust-bech32#17 is merged and the rust-bech32 crate is released to crates.io