### PR TITLE
Add travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: rust
+rust:
+  - stable
+  - nightly
+  - 1.14.0  # shipping debian version 2018 03
+cache: cargo

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,6 +291,8 @@ impl error::Error for Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bech32;
+    use constants::Network;
 
     #[test]
     fn valid_address() {


### PR DESCRIPTION
Add `.travis.yml` and some `use` statements in tests to make them compile with 1.14.