### PR TITLE
Add Bitcoin-core regtest bech32 addresses support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-bech32"
-version = "0.5.1"
+version = "0.7.0"
 authors = ["Clark Moody"]
 repository = "https://github.com/rust-bitcoin/rust-bech32-bitcoin"
 description = "Encodes and decodes Bitcoin Segregated Witness addresses in Bech32"

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -38,6 +38,9 @@ pub enum Network {
     Vertcoin,
     /// Vertcoin testnet
     VertcoinTestnet,
+    /// Bitcoin-Core Regtest,
+    BitcoinCoreRegtest,
+
 }
 
 /// Returns the Human-readable part for the given network
@@ -49,6 +52,7 @@ pub fn hrp(network: &Network) -> String {
         Network::LitecoinTestnet => "tltc".to_string(),
         Network::Vertcoin => "vtc".to_string(),
         Network::VertcoinTestnet => "tvtc".to_string(),
+        Network::BitcoinCoreRegtest => "bcrt".to_string(),
     }
 }
 
@@ -61,6 +65,7 @@ pub fn classify(hrp: &str) -> Option<Network> {
         "tltc" => Some(Network::LitecoinTestnet),
         "vtc" => Some(Network::Vertcoin),
         "tvtc" => Some(Network::VertcoinTestnet),
+        "bcrt" => Some(Network::BitcoinCoreRegtest),
         _ => None
     }
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -30,6 +30,8 @@ pub enum Network {
     Bitcoin,
     /// Bitcoin testnet
     Testnet,
+    /// Bitcoin regtest,
+    Regtest,
     /// Litecoin mainnet
     Litecoin,
     /// Litecoin testnet
@@ -38,9 +40,6 @@ pub enum Network {
     Vertcoin,
     /// Vertcoin testnet
     VertcoinTestnet,
-    /// Bitcoin-Core Regtest,
-    BitcoinCoreRegtest,
-
 }
 
 /// Returns the Human-readable part for the given network
@@ -52,7 +51,7 @@ pub fn hrp(network: &Network) -> String {
         Network::LitecoinTestnet => "tltc".to_string(),
         Network::Vertcoin => "vtc".to_string(),
         Network::VertcoinTestnet => "tvtc".to_string(),
-        Network::BitcoinCoreRegtest => "bcrt".to_string(),
+        Network::Regtest => "bcrt".to_string(),
     }
 }
 
@@ -65,7 +64,7 @@ pub fn classify(hrp: &str) -> Option<Network> {
         "tltc" => Some(Network::LitecoinTestnet),
         "vtc" => Some(Network::Vertcoin),
         "tvtc" => Some(Network::VertcoinTestnet),
-        "bcrt" => Some(Network::BitcoinCoreRegtest),
+        "bcrt" => Some(Network::Regtest),
         _ => None
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,6 +348,14 @@ mod tests {
                 ],
                 Network::Testnet,
             ),
+            (
+                "bcrt1qn3h68k2u0rr49skx05qw7veynpf4lfppd2demt",
+               vec![
+                    0x00, 0x14, 0x9c, 0x6f, 0xa3, 0xd9, 0x5c, 0x78, 0xc7, 0x52, 0xc2,
+                    0xc6, 0x7d, 0x00, 0xef, 0x33, 0x24, 0x98, 0x53, 0x5f, 0xa4, 0x21,
+                ],
+               Network::BitcoinCoreRegtest,
+            ),
         ];
         for p in pairs {
             let (address, scriptpubkey, network) = p;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,11 +350,11 @@ mod tests {
             ),
             (
                 "bcrt1qn3h68k2u0rr49skx05qw7veynpf4lfppd2demt",
-               vec![
+                vec![
                     0x00, 0x14, 0x9c, 0x6f, 0xa3, 0xd9, 0x5c, 0x78, 0xc7, 0x52, 0xc2,
                     0xc6, 0x7d, 0x00, 0xef, 0x33, 0x24, 0x98, 0x53, 0x5f, 0xa4, 0x21,
                 ],
-               Network::BitcoinCoreRegtest,
+                Network::Regtest,
             ),
         ];
         for p in pairs {


### PR DESCRIPTION
Bitcoin-core addresses on regtest start with "bcrt1".
While this is not part of BIP173, adding the support allows library users to use bitcoin-core regtest to end-to-end test their rust software.

Please note that I would like to do a similar pull request for repo rust-bitcoin. However, rust-bech32-bitcoin/master contains breaking changes which means that rust-bitcoin/master cannot compile with the current bech32/master.

I had to create a branch based from commit 4d08819007b3c1da965a79424eb046017441ccd0 to implement my changes and use them with rust-bitcoin/master.

If you are happy with integrating this pull request, could you please assist in creating a release 0.5.2? (0.5.1 + this pull request). I cannot see a dedicated branch/tag for 0.5.1 in this repo.

Many thanks for considering my request and in providing this very useful library!