### PR TITLE
Bump bech32 dependency version to v0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ categories = ["encoding"]
 license = "MIT"
 
 [dependencies]
-bech32 = "0.5.0"
+bech32 = "0.6"


### PR DESCRIPTION
This makes it compliant with the lightning-invoice crate.