### PR TITLE
Bump minor version after updating bech32 dependency to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-bech32"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Clark Moody"]
 repository = "https://github.com/rust-bitcoin/rust-bech32-bitcoin"
 description = "Encodes and decodes Bitcoin Segregated Witness addresses in Bech32"


### PR DESCRIPTION
After #20, we need to bump package version. 