### PR TITLE
signet: fix bech32

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -53,7 +53,7 @@ pub fn hrp(network: &Network) -> String {
     match *network {
         Network::Bitcoin => "bc".to_string(),
         Network::Testnet => "tb".to_string(),
-        Network::Signet => "sb".to_string(),
+        Network::Signet => "tb".to_string(),
         Network::Groestlcoin => "grs".to_string(),
         Network::GroestlcoinTestnet => "tgrs".to_string(),
         Network::Litecoin => "ltc".to_string(),
@@ -69,7 +69,6 @@ pub fn classify(hrp: &str) -> Option<Network> {
     match hrp {
         "bc" => Some(Network::Bitcoin),
         "tb" => Some(Network::Testnet),
-        "sb" => Some(Network::Signet),
         "grs" => Some(Network::Groestlcoin),
         "tgrs" => Some(Network::GroestlcoinTestnet),
         "ltc" => Some(Network::Litecoin),


### PR DESCRIPTION
Signet was switched last minute to use the same bech32 hrp as testnet. This PR reflects that change.