### PR TITLE
Standard derives for error types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-bech32"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Clark Moody"]
 repository = "https://github.com/rust-bitcoin/rust-bech32-bitcoin"
 description = "Encodes and decodes Bitcoin Segregated Witness addresses in Bech32"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,7 +248,7 @@ fn program_version_to_variant(version: u5) -> Option<Variant> {
 ///
 /// BIP141 specifies Segregated Witness and defines valid program lengths
 /// for Version 0 scripts. Script version is also limited to values 0-16.
-#[derive(PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum Error {
     /// Some Bech32 conversion error
     Bech32(bech32::Error),


### PR DESCRIPTION
Based on https://github.com/rust-bitcoin/rust-bech32/pull/49, will be ready for merge once new version of `rust-bech32` will be published