### PR TITLE
Minor QOL fixes

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -49,18 +49,18 @@ pub enum Network {
 }
 
 /// Returns the Human-readable part for the given network
-pub fn hrp(network: &Network) -> String {
-    match *network {
-        Network::Bitcoin => "bc".to_string(),
-        Network::Testnet => "tb".to_string(),
-        Network::Signet => "tb".to_string(),
-        Network::Groestlcoin => "grs".to_string(),
-        Network::GroestlcoinTestnet => "tgrs".to_string(),
-        Network::Litecoin => "ltc".to_string(),
-        Network::LitecoinTestnet => "tltc".to_string(),
-        Network::Vertcoin => "vtc".to_string(),
-        Network::VertcoinTestnet => "tvtc".to_string(),
-        Network::Regtest => "bcrt".to_string(),
+pub fn hrp(network: &Network) -> &'static str {
+    match network {
+        Network::Bitcoin => "bc",
+        Network::Testnet => "tb",
+        Network::Signet => "tb",
+        Network::Groestlcoin => "grs",
+        Network::GroestlcoinTestnet => "tgrs",
+        Network::Litecoin => "ltc",
+        Network::LitecoinTestnet => "tltc",
+        Network::Vertcoin => "vtc",
+        Network::VertcoinTestnet => "tvtc",
+        Network::Regtest => "bcrt",
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,8 +189,8 @@ impl WitnessProgram {
     }
 
     /// Which network this witness program is intended to be run on
-    pub fn network(&self) -> Network {
-        self.network
+    pub fn network(&self) -> &Network {
+        &self.network
     }
 }
 
@@ -418,7 +418,7 @@ mod tests {
             let pubkey = prog.to_scriptpubkey();
             assert_eq!(pubkey, scriptpubkey);
 
-            assert_eq!(prog.network(), network);
+            assert_eq!(prog.network(), &network);
             assert_eq!(prog.version().to_u8(), version);
             assert_eq!(prog.program(), &scriptpubkey[2..]); // skip version and length
 


### PR DESCRIPTION
Those changes aren't groundbreaking.
One avoids allocating a new String every time a Network is converted to his string representation, a user can always call to_owned or clone on the static string to get the owned String.
The other one returns a reference to Network instead of copying it every time, I feel this is more correct since, for example, `constants::hrp` asks for a reference, therefore we can short circuit the two things without creating a temporary reference to a temporary copy only for this